### PR TITLE
Add admin-only login gate

### DIFF
--- a/BlazorLogin/Components/App.razor
+++ b/BlazorLogin/Components/App.razor
@@ -1,12 +1,18 @@
-<Router AppAssembly="typeof(App).Assembly">
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="typeof(MainLayout)" />
-        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-    </Found>
-    <NotFound>
-        <PageTitle>Not found</PageTitle>
-        <LayoutView Layout="typeof(MainLayout)">
-            <p role="alert">Sorry, there's nothing at this address.</p>
-        </LayoutView>
-    </NotFound>
-</Router>
+<CascadingAuthenticationState>
+    <Router AppAssembly="typeof(App).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="typeof(MainLayout)">
+                <NotAuthorized>
+                    <RedirectToLogin />
+                </NotAuthorized>
+            </AuthorizeRouteView>
+            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+        </Found>
+        <NotFound>
+            <PageTitle>Not found</PageTitle>
+            <LayoutView Layout="typeof(MainLayout)">
+                <p role="alert">Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>

--- a/BlazorLogin/Components/Layout/NavMenu.razor
+++ b/BlazorLogin/Components/Layout/NavMenu.razor
@@ -1,17 +1,44 @@
-<nav class="nav-menu">
-    <div class="nav-item px-3">
-        <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-            Home
-        </NavLink>
-    </div>
-    <div class="nav-item px-3">
-        <NavLink class="nav-link" href="counter">
-            Counter
-        </NavLink>
-    </div>
-    <div class="nav-item px-3">
-        <NavLink class="nav-link" href="weather">
-            Weather
-        </NavLink>
-    </div>
-</nav>
+@inject SimpleAuthenticationStateProvider AuthProvider
+@inject NavigationManager Navigation
+
+<AuthorizeView>
+    <Authorized>
+        <nav class="nav-menu">
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="home" Match="NavLinkMatch.All">
+                    Home
+                </NavLink>
+            </div>
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="counter">
+                    Counter
+                </NavLink>
+            </div>
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="weather">
+                    Weather
+                </NavLink>
+            </div>
+            <div class="nav-item px-3">
+                <button class="btn btn-link nav-link px-0" type="button" @onclick="Logout">Cerrar sesión</button>
+            </div>
+        </nav>
+    </Authorized>
+    <NotAuthorized>
+        <nav class="nav-menu">
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
+                    Login
+                </NavLink>
+            </div>
+        </nav>
+    </NotAuthorized>
+</AuthorizeView>
+
+@code {
+    private async Task Logout()
+    {
+        await AuthProvider.LogoutAsync();
+        Navigation.NavigateTo("/", true);
+    }
+}

--- a/BlazorLogin/Components/Pages/Counter.razor
+++ b/BlazorLogin/Components/Pages/Counter.razor
@@ -1,4 +1,5 @@
 @page "/counter"
+@attribute [Authorize]
 <PageTitle>Counter</PageTitle>
 
 <h1>Counter</h1>

--- a/BlazorLogin/Components/Pages/FetchData.razor
+++ b/BlazorLogin/Components/Pages/FetchData.razor
@@ -1,5 +1,6 @@
 @page "/weather"
 @inject WeatherForecastService ForecastService
+@attribute [Authorize]
 <PageTitle>Weather forecast</PageTitle>
 
 <h1>Weather forecast</h1>

--- a/BlazorLogin/Components/Pages/Home.razor
+++ b/BlazorLogin/Components/Pages/Home.razor
@@ -1,4 +1,5 @@
-@page "/"
+@page "/home"
+@attribute [Authorize]
 <PageTitle>Home</PageTitle>
 
 <h1>Hello, world!</h1>

--- a/BlazorLogin/Components/Pages/Login.razor
+++ b/BlazorLogin/Components/Pages/Login.razor
@@ -1,0 +1,65 @@
+@page "/"
+@attribute [AllowAnonymous]
+@using System.ComponentModel.DataAnnotations
+@inject SimpleAuthenticationStateProvider AuthProvider
+@inject NavigationManager Navigation
+
+<PageTitle>Login</PageTitle>
+
+<h1>Iniciar sesión</h1>
+
+@if (!string.IsNullOrEmpty(ErrorMessage))
+{
+    <div class="alert alert-danger" role="alert">@ErrorMessage</div>
+}
+
+<EditForm Model="credentials" OnValidSubmit="HandleLoginAsync">
+    <DataAnnotationsValidator />
+    <ValidationSummary />
+    <div class="mb-3">
+        <label class="form-label" for="username">Usuario</label>
+        <InputText id="username" class="form-control" @bind-Value="credentials.Username" autocomplete="username" />
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="password">Contraseña</label>
+        <InputText id="password" type="password" class="form-control" @bind-Value="credentials.Password" autocomplete="current-password" />
+    </div>
+    <button class="btn btn-primary" type="submit">Ingresar</button>
+</EditForm>
+
+@code {
+    private readonly LoginModel credentials = new();
+    private string? ErrorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthProvider.GetAuthenticationStateAsync();
+        if (authState.User.Identity?.IsAuthenticated == true)
+        {
+            Navigation.NavigateTo("/home", true);
+        }
+    }
+
+    private async Task HandleLoginAsync()
+    {
+        var success = await AuthProvider.LoginAsync(credentials.Username, credentials.Password);
+        if (success)
+        {
+            ErrorMessage = null;
+            Navigation.NavigateTo("/home", true);
+        }
+        else
+        {
+            ErrorMessage = "Usuario o contraseña inválidos.";
+        }
+    }
+
+    private sealed class LoginModel
+    {
+        [Required(ErrorMessage = "El usuario es obligatorio.")]
+        public string Username { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "La contraseña es obligatoria.")]
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/BlazorLogin/Components/RedirectToLogin.razor
+++ b/BlazorLogin/Components/RedirectToLogin.razor
@@ -1,0 +1,11 @@
+@inject NavigationManager Navigation
+
+@code {
+    protected override void OnInitialized()
+    {
+        if (!Navigation.Uri.Equals(Navigation.BaseUri, System.StringComparison.OrdinalIgnoreCase))
+        {
+            Navigation.NavigateTo("/", true);
+        }
+    }
+}

--- a/BlazorLogin/Components/_Imports.razor
+++ b/BlazorLogin/Components/_Imports.razor
@@ -7,7 +7,10 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.AspNetCore.Components.RenderTree
 @using Microsoft.JSInterop
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
 @using BlazorLogin
 @using BlazorLogin.Components
 @using BlazorLogin.Components.Layout
 @using BlazorLogin.Data
+@using BlazorLogin.Services

--- a/BlazorLogin/Program.cs
+++ b/BlazorLogin/Program.cs
@@ -1,5 +1,7 @@
 using BlazorLogin.Components;
 using BlazorLogin.Data;
+using BlazorLogin.Services;
+using Microsoft.AspNetCore.Components.Authorization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -8,6 +10,9 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 builder.Services.AddSingleton<WeatherForecastService>();
+builder.Services.AddAuthorizationCore();
+builder.Services.AddScoped<SimpleAuthenticationStateProvider>();
+builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<SimpleAuthenticationStateProvider>());
 
 var app = builder.Build();
 

--- a/BlazorLogin/Services/SimpleAuthenticationStateProvider.cs
+++ b/BlazorLogin/Services/SimpleAuthenticationStateProvider.cs
@@ -1,0 +1,47 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace BlazorLogin.Services;
+
+public class SimpleAuthenticationStateProvider : AuthenticationStateProvider
+{
+    private readonly ClaimsPrincipal _anonymous = new(new ClaimsIdentity());
+    private ClaimsPrincipal _currentPrincipal;
+
+    public SimpleAuthenticationStateProvider()
+    {
+        _currentPrincipal = _anonymous;
+    }
+
+    public override Task<AuthenticationState> GetAuthenticationStateAsync()
+        => CreateAuthenticationState();
+
+    public Task<bool> LoginAsync(string username, string password)
+    {
+        if (username == "admin" && password == "admin")
+        {
+            var identity = new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.Name, username)
+            }, authenticationType: "SimpleAuth");
+
+            _currentPrincipal = new ClaimsPrincipal(identity);
+            NotifyAuthenticationStateChanged(CreateAuthenticationState());
+            return Task.FromResult(true);
+        }
+
+        _currentPrincipal = _anonymous;
+        NotifyAuthenticationStateChanged(CreateAuthenticationState());
+        return Task.FromResult(false);
+    }
+
+    public Task LogoutAsync()
+    {
+        _currentPrincipal = _anonymous;
+        NotifyAuthenticationStateChanged(CreateAuthenticationState());
+        return Task.CompletedTask;
+    }
+
+    private Task<AuthenticationState> CreateAuthenticationState()
+        => Task.FromResult(new AuthenticationState(_currentPrincipal));
+}


### PR DESCRIPTION
## Summary
- register a simple authentication state provider backed by admin/admin credentials and wire it into the Blazor app
- add a login page as the default route, gate existing pages behind authorization, and update navigation/redirect behavior

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d47e016ea0832ca02b53f2f1b406c7